### PR TITLE
`cron-validate`のoverrideを置く場所を`job-manager`に

### DIFF
--- a/ghost/job-manager/package.json
+++ b/ghost/job-manager/package.json
@@ -34,5 +34,8 @@
     "cron-validate": "1.4.5",
     "fastq": "1.15.0",
     "p-wait-for": "3.2.0"
+  },
+  "overrides": {
+    "cron-validate": "1.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -130,8 +130,5 @@
     "lint-staged": "13.2.3",
     "nx": "16.5.2",
     "ts-node": "10.9.1"
-  },
-  "overrides": {
-    "cron-validate": "1.4.5"
   }
 }


### PR DESCRIPTION
呼び出し元の`bree`を使っているのがここであるため