### PR TITLE
MariaDBをMySQLに移行

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -15,19 +15,19 @@ services:
     tty: true
     restart: always
     depends_on:
-      - maria
+      - mysql
     command: >
-      bash -c "dockerize -wait tcp://maria:3306 &&
+      bash -c "dockerize -wait tcp://mysql:3306 &&
       node /srv/ghost/index.js"
-  maria:
-    image: mariadb:10.11.4
-    container_name: maria
+  mysql:
+    image: mysql:8.0
+    container_name: mysql
     volumes:
-      - maria-volume:/var/lib/maria
+      - mysql-volume:/var/lib/mysql
       - ./conf.d:/etc/mysql/conf.d:ro
     restart: always
     environment:
-      MYSQL_ROOT_HOST: maria
+      MYSQL_ROOT_HOST: mysql
       MYSQL_ROOT_PASSWORD: ghost
       MYSQL_USER: ghost
       MYSQL_PASSWORD: pass
@@ -36,4 +36,4 @@ services:
       - 3306
 
 volumes:
-  maria-volume:
+  mysql-volume:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,8 @@ RUN cp ./ghost/core/ghost-${GHOST_VERSION}.tgz ./ghost.tgz && \
   tar -xzf ./ghost.tgz && \
   rm ./ghost.tgz && \
   mkdir -p /srv/ghost && \
-  mv ./package/* /srv/ghost
+  mv ./package/* /srv/ghost && \
+  cp yarn.lock /srv/ghost/yarn.lock
 
 COPY ./ghost/core/content/themes/ghost-theme-2020 /srv/ghost/content/themes/ghost-theme-2020
 

--- a/docker/DockerfileDockerize
+++ b/docker/DockerfileDockerize
@@ -17,7 +17,8 @@ RUN cp ./ghost/core/ghost-${GHOST_VERSION}.tgz ./ghost.tgz && \
   tar -xzf ./ghost.tgz && \
   rm ./ghost.tgz && \
   mkdir -p /srv/ghost && \
-  mv ./package/* /srv/ghost
+  mv ./package/* /srv/ghost && \
+  cp yarn.lock /srv/ghost/yarn.lock
 
 # s3 adaptorを移動
 RUN mkdir -p /srv/ghost/content/adapters/storage && \ 

--- a/docker/config.production.json
+++ b/docker/config.production.json
@@ -7,7 +7,7 @@
   "database": {
     "client": "mysql",
     "connection": {
-      "host": "maria",
+      "host": "mysql",
       "port": 3306,
       "user": "ghost",
       "password": "pass",


### PR DESCRIPTION
MariaDBはサポートされなくなったため、MySQLに移行させます。
ビルドすると `got` というライブラリがnodeバージョンのエラーを吐くので、`yarn.lock` をコピーしてそれを参照させるようにしています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * データベースバックエンドをMariaDBからMySQLに切り替えました。本番環境の安定性と互換性の向上を実現します。
  * Docker環境設定を更新し、新しいデータベースバージョンに対応させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/Ghost/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->