### PR TITLE
frozen lockfileを削除

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,6 @@ RUN apt-get update && apt-get install -y git
 ENV NODE_ENV production
 COPY --from=builder /srv/ghost /srv/ghost
 WORKDIR /srv/ghost
-RUN yarn install --frozen-lockfile && yarn cache clean
+RUN yarn install && yarn cache clean
 EXPOSE 2368
 CMD ["node", "./index.js"]


### PR DESCRIPTION
--frozen-lockfileがあるとyarn.lockとpackage.jsonとの間の不整合を直してくれないらしく落ちる。DockerfileDockerizeは手元で動くことを確認しているので--frozen-lockfileを削除すれば動くはず

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker ビルドプロセスの依存解決オプションを調整しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/Ghost/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->